### PR TITLE
replace AppCompatActivity to FragmentActivity

### DIFF
--- a/androidx/src/main/java/me/vponomarenko/injectionmanager/x/XActivityLifecycleHelper.kt
+++ b/androidx/src/main/java/me/vponomarenko/injectionmanager/x/XActivityLifecycleHelper.kt
@@ -3,7 +3,7 @@ package me.vponomarenko.injectionmanager.x
 import android.app.Activity
 import android.app.Application
 import android.os.Bundle
-import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.FragmentActivity
 import me.vponomarenko.injectionmanager.IHasComponent
 import me.vponomarenko.injectionmanager.callbacks.IRemoveComponentCallback
 
@@ -39,7 +39,7 @@ internal class XActivityLifecycleHelper(
     }
 
     override fun onActivityCreated(activity: Activity, outState: Bundle?) {
-        if (activity is AppCompatActivity) {
+        if (activity is FragmentActivity) {
             activity.supportFragmentManager.registerFragmentLifecycleCallbacks(
                 XFragmentLifecycleHelper(removeComponentCallback),
                 true

--- a/appcompat/src/main/java/me/vponomarenko/injectionmanager/support/CompatActivityLifecycleHelper.kt
+++ b/appcompat/src/main/java/me/vponomarenko/injectionmanager/support/CompatActivityLifecycleHelper.kt
@@ -3,7 +3,7 @@ package me.vponomarenko.injectionmanager.support
 import android.app.Activity
 import android.app.Application
 import android.os.Bundle
-import android.support.v7.app.AppCompatActivity
+import android.support.v4.app.FragmentActivity
 import me.vponomarenko.injectionmanager.IHasComponent
 import me.vponomarenko.injectionmanager.callbacks.IRemoveComponentCallback
 
@@ -39,7 +39,7 @@ internal class CompatActivityLifecycleHelper(
     }
 
     override fun onActivityCreated(activity: Activity, outState: Bundle?) {
-        if (activity is AppCompatActivity) {
+        if (activity is FragmentActivity) {
             activity.supportFragmentManager.registerFragmentLifecycleCallbacks(
                 CompatFragmentLifecycleHelper(removeComponentCallback),
                 true


### PR DESCRIPTION
We need to replace AppCompatActivity to FragmentActivity, for instance, if an activity extends only FragmentActivity we have to use a custom lifecycle of a component